### PR TITLE
[AB] Support custom dataset metrics without labels

### DIFF
--- a/superset-frontend/plugins/plugin-aven-ab-chart/src/AvenABChart.tsx
+++ b/superset-frontend/plugins/plugin-aven-ab-chart/src/AvenABChart.tsx
@@ -145,12 +145,16 @@ function buildRow(
     denominatorMetric,
   );
   const lastDelta = deltaArray.at(-1);
-  if (!lastControl || !lastTest || !lastDelta) {
+  if (
+    lastControl === undefined ||
+    lastTest === undefined ||
+    lastDelta === undefined
+  ) {
     throw new Error('empty arrays');
   }
 
   const color =
-    lastDelta > -0.00001 && lastDelta < 0.00001
+    lastDelta === null || (lastDelta > -0.00001 && lastDelta < 0.00001)
       ? 'black'
       : lastDelta < 0
         ? 'red'
@@ -183,7 +187,10 @@ function buildRow(
     ),
     delta_rel: (
       <span style={{ color }}>
-        <FormattedNumber num={lastDelta} format="+.1%" />
+        <FormattedNumber
+          num={lastDelta !== null ? lastDelta : undefined}
+          format="+.1%"
+        />
       </span>
     ),
     spark: renderSparklineCell(deltaArray, 'abc', timestamps),

--- a/superset-frontend/plugins/plugin-aven-ab-chart/src/plugin/transformProps.ts
+++ b/superset-frontend/plugins/plugin-aven-ab-chart/src/plugin/transformProps.ts
@@ -92,7 +92,9 @@ export default function transformProps(chartProps: ChartProps) {
     ),
   ].sort();
 
-  const metricsNames = formData.metrics.map((v: { label: string }) => v.label);
+  const metricsNames = formData.metrics.map((v: string | { label: string }) =>
+    typeof v === 'string' ? v : v.label,
+  );
   const unqMetricNames = [...new Set(metricsNames)];
   if (metricsNames.length !== unqMetricNames.length) {
     throw new Error('ALl metrics need unique names');


### PR DESCRIPTION
Custom dataset metrics may not have label and break the chart.

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
