### PR TITLE
fix: CI infrastructure fixes (pre-commit, config.py, load_examples)

### DIFF
--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -112,11 +112,16 @@ testdata() {
   pip install -e .
   superset db upgrade
   superset load_test_users
-  # Use --only-metadata to create table schemas without downloading data
-  # from GitHub (avoids HTTP 429 rate limiting when multiple CI jobs run
-  # in parallel). Test data tables will have schemas but no rows from
-  # external sources — energy test data is loaded separately.
-  superset load_examples --only-metadata --load-test-data
+  # Pre-download example data with curl retry to avoid HTTP 429 when
+  # multiple CI jobs fetch from raw.githubusercontent.com in parallel.
+  mkdir -p /tmp/examples-data
+  local base="https://github.com/apache-superset/examples-data/blob/master"
+  for f in countries.json.gz birth_names2.json.gz energy.json.gz; do
+    curl -sSL --retry 10 --retry-delay 15 --retry-all-errors \
+      -o "/tmp/examples-data/$f" "$base/$f?raw=true"
+  done
+  export SUPERSET_EXAMPLES_BASE_URL="file:///tmp/examples-data/"
+  superset load_examples --load-test-data
   superset init
   say "::endgroup::"
 }

--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -112,27 +112,11 @@ testdata() {
   pip install -e .
   superset db upgrade
   superset load_test_users
-  # Stagger start + retry with backoff — multiple CI jobs downloading example
-  # data from GitHub simultaneously triggers HTTP 429 rate limiting.
-  # Random initial delay (0-60s) spreads jobs across the rate limit window.
-  local jitter=$((RANDOM % 60))
-  say "Waiting ${jitter}s before loading examples (stagger to avoid rate limits)..."
-  sleep $jitter
-  local max_attempts=5
-  local attempt=1
-  while [ $attempt -le $max_attempts ]; do
-    if superset load_examples --load-test-data; then
-      break
-    fi
-    if [ $attempt -eq $max_attempts ]; then
-      say "load_examples failed after $max_attempts attempts"
-      exit 1
-    fi
-    local wait=$((attempt * 60 + RANDOM % 30))
-    say "load_examples attempt $attempt failed, retrying in ${wait}s..."
-    sleep $wait
-    attempt=$((attempt + 1))
-  done
+  # Use --only-metadata to create table schemas without downloading data
+  # from GitHub (avoids HTTP 429 rate limiting when multiple CI jobs run
+  # in parallel). Test data tables will have schemas but no rows from
+  # external sources — energy test data is loaded separately.
+  superset load_examples --only-metadata --load-test-data
   superset init
   say "::endgroup::"
 }

--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -112,7 +112,22 @@ testdata() {
   pip install -e .
   superset db upgrade
   superset load_test_users
-  superset load_examples --load-test-data
+  # Retry load_examples with backoff — multiple CI jobs downloading example data
+  # from GitHub simultaneously often triggers HTTP 429 rate limiting.
+  local max_attempts=3
+  local attempt=1
+  while [ $attempt -le $max_attempts ]; do
+    if superset load_examples --load-test-data; then
+      break
+    fi
+    if [ $attempt -eq $max_attempts ]; then
+      say "load_examples failed after $max_attempts attempts"
+      exit 1
+    fi
+    say "load_examples attempt $attempt failed, retrying in $((attempt * 30))s..."
+    sleep $((attempt * 30))
+    attempt=$((attempt + 1))
+  done
   superset init
   say "::endgroup::"
 }

--- a/.github/workflows/bashlib.sh
+++ b/.github/workflows/bashlib.sh
@@ -112,9 +112,13 @@ testdata() {
   pip install -e .
   superset db upgrade
   superset load_test_users
-  # Retry load_examples with backoff — multiple CI jobs downloading example data
-  # from GitHub simultaneously often triggers HTTP 429 rate limiting.
-  local max_attempts=3
+  # Stagger start + retry with backoff — multiple CI jobs downloading example
+  # data from GitHub simultaneously triggers HTTP 429 rate limiting.
+  # Random initial delay (0-60s) spreads jobs across the rate limit window.
+  local jitter=$((RANDOM % 60))
+  say "Waiting ${jitter}s before loading examples (stagger to avoid rate limits)..."
+  sleep $jitter
+  local max_attempts=5
   local attempt=1
   while [ $attempt -le $max_attempts ]; do
     if superset load_examples --load-test-data; then
@@ -124,8 +128,9 @@ testdata() {
       say "load_examples failed after $max_attempts attempts"
       exit 1
     fi
-    say "load_examples attempt $attempt failed, retrying in $((attempt * 30))s..."
-    sleep $((attempt * 30))
+    local wait=$((attempt * 60 + RANDOM % 30))
+    say "load_examples attempt $attempt failed, retrying in ${wait}s..."
+    sleep $wait
     attempt=$((attempt + 1))
   done
   superset init

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -35,6 +35,7 @@ jobs:
           brew install norwoodj/tap/helm-docs
       - name: pre-commit
         run: |
+          pip install nodeenv --upgrade
           if ! pre-commit run --all-files; then
             git status
             git diff

--- a/.github/workflows/superset-cli.yml
+++ b/.github/workflows/superset-cli.yml
@@ -63,17 +63,7 @@ jobs:
       - name: superset load_examples
         if: steps.check.outputs.python
         run: |
-          # load examples without test data (retry with backoff for GitHub rate limits)
-          sleep $((RANDOM % 60))
-          for attempt in 1 2 3 4 5; do
-            if superset load_examples --load-big-data; then
-              break
-            fi
-            if [ "$attempt" -eq 5 ]; then
-              echo "load_examples failed after 5 attempts"
-              exit 1
-            fi
-            wait=$((attempt * 60 + RANDOM % 30))
-            echo "load_examples attempt $attempt failed, retrying in ${wait}s..."
-            sleep $wait
-          done
+          # Use --only-metadata to skip external downloads from GitHub
+          # (avoids HTTP 429 rate limiting when multiple CI jobs run in parallel).
+          # --load-big-data generates synthetic test data locally.
+          superset load_examples --only-metadata --load-big-data

--- a/.github/workflows/superset-cli.yml
+++ b/.github/workflows/superset-cli.yml
@@ -62,8 +62,19 @@ jobs:
           superset load_test_users
       - name: superset load_examples
         if: steps.check.outputs.python
+        env:
+          SUPERSET_EXAMPLES_BASE_URL: "file:///tmp/examples-data/"
         run: |
-          # Use --only-metadata to skip external downloads from GitHub
-          # (avoids HTTP 429 rate limiting when multiple CI jobs run in parallel).
-          # --load-big-data generates synthetic test data locally.
-          superset load_examples --only-metadata --load-big-data
+          # Pre-download example data with curl retry to avoid HTTP 429 when
+          # multiple CI jobs fetch from raw.githubusercontent.com in parallel.
+          mkdir -p /tmp/examples-data
+          BASE="https://github.com/apache-superset/examples-data/blob/master"
+          for f in countries.json.gz birth_names2.json.gz random_time_series.json.gz \
+                   san_francisco.csv.gz flight_data.csv.gz airports.csv.gz \
+                   sf_population.json.gz paris_iris.json.gz \
+                   multiformat_time_series.json.gz bart-lines.json.gz \
+                   birth_france_data_for_country_map.csv; do
+            curl -sSL --retry 10 --retry-delay 15 --retry-all-errors \
+              -o "/tmp/examples-data/$f" "$BASE/$f?raw=true"
+          done
+          superset load_examples --load-big-data

--- a/.github/workflows/superset-cli.yml
+++ b/.github/workflows/superset-cli.yml
@@ -63,5 +63,15 @@ jobs:
       - name: superset load_examples
         if: steps.check.outputs.python
         run: |
-          # load examples without test data
-          superset load_examples --load-big-data
+          # load examples without test data (retry with backoff for GitHub rate limits)
+          for attempt in 1 2 3; do
+            if superset load_examples --load-big-data; then
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "load_examples failed after 3 attempts"
+              exit 1
+            fi
+            echo "load_examples attempt $attempt failed, retrying in $((attempt * 30))s..."
+            sleep $((attempt * 30))
+          done

--- a/.github/workflows/superset-cli.yml
+++ b/.github/workflows/superset-cli.yml
@@ -64,14 +64,16 @@ jobs:
         if: steps.check.outputs.python
         run: |
           # load examples without test data (retry with backoff for GitHub rate limits)
-          for attempt in 1 2 3; do
+          sleep $((RANDOM % 60))
+          for attempt in 1 2 3 4 5; do
             if superset load_examples --load-big-data; then
               break
             fi
-            if [ "$attempt" -eq 3 ]; then
-              echo "load_examples failed after 3 attempts"
+            if [ "$attempt" -eq 5 ]; then
+              echo "load_examples failed after 5 attempts"
               exit 1
             fi
-            echo "load_examples attempt $attempt failed, retrying in $((attempt * 30))s..."
-            sleep $((attempt * 30))
+            wait=$((attempt * 60 + RANDOM % 30))
+            echo "load_examples attempt $attempt failed, retrying in ${wait}s..."
+            sleep $wait
           done

--- a/superset/config.py
+++ b/superset/config.py
@@ -39,7 +39,6 @@ from importlib.resources import files
 from typing import Any, Callable, Literal, TYPE_CHECKING, TypedDict
 
 import click
-import pkg_resources
 from celery.schedules import crontab
 from flask import Blueprint
 from flask_appbuilder.security.manager import AUTH_DB
@@ -86,7 +85,7 @@ EVENT_LOGGER = DBEventLogger()
 
 SUPERSET_LOG_VIEW = True
 
-BASE_DIR = pkg_resources.resource_filename("superset", "")
+BASE_DIR = str(files("superset"))
 if "SUPERSET_HOME" in os.environ:
     DATA_DIR = os.environ["SUPERSET_HOME"]
 else:

--- a/superset/examples/helpers.py
+++ b/superset/examples/helpers.py
@@ -22,7 +22,10 @@ from superset.connectors.sqla.models import SqlaTable
 from superset.models.slice import Slice
 from superset.utils import json
 
-BASE_URL = "https://github.com/apache-superset/examples-data/blob/master/"
+BASE_URL = os.environ.get(
+    "SUPERSET_EXAMPLES_BASE_URL",
+    "https://github.com/apache-superset/examples-data/blob/master/",
+)
 
 misc_dash_slices: set[str] = set()  # slices assembled in a 'Misc Chart' dashboard
 
@@ -69,4 +72,6 @@ def get_slice_json(defaults: dict[Any, Any], **kwargs: Any) -> str:
 
 
 def get_example_url(filepath: str) -> str:
+    if BASE_URL.startswith("file://"):
+        return f"{BASE_URL}{filepath}"
     return f"{BASE_URL}{filepath}?raw=true"


### PR DESCRIPTION
## Summary

Fixes three CI infrastructure issues that affect all PRs in this repo.

### 1. Pre-commit `nodeenv` fix
**Problem:** `nodeenv 1.8.0` imports `pkg_resources` which was removed from newer Python 3.10 GitHub Actions runner images, causing pre-commit to fail.
**Fix:** Added `pip install nodeenv --upgrade` before `pre-commit run` in `.github/workflows/pre-commit.yml`.

### 2. `pkg_resources` removal in `superset/config.py`
**Problem:** `superset/config.py` uses `pkg_resources.resource_filename()` which triggers the same deprecation/removal issue.
**Fix:** Replaced with `importlib.resources` equivalent.

### 3. `load_examples` HTTP 429 rate limiting
**Problem:** `superset load_examples` downloads ~12 data files from `raw.githubusercontent.com`. With 7+ CI jobs running in parallel (6 cypress + 1 superset-cli), GitHub rate-limits them with HTTP 429. Retrying at the shell level does not help because each retry re-triggers the same downloads via `pd.read_json(url)` which has no retry logic.

**Fix:** Three-part approach:
- **`superset/examples/helpers.py`**: Made `BASE_URL` configurable via `SUPERSET_EXAMPLES_BASE_URL` env var. When set to a `file://` URL, skips the `?raw=true` query parameter.
- **`.github/workflows/superset-cli.yml`**: Pre-downloads all 11 data files using `curl --retry 10 --retry-delay 15 --retry-all-errors` to `/tmp/examples-data/`, then sets `SUPERSET_EXAMPLES_BASE_URL=file:///tmp/examples-data/` so `load_examples` reads from local files.
- **`.github/workflows/bashlib.sh`**: Same curl pre-download approach for the 3 files needed by cypress E2E tests (`countries.json.gz`, `birth_names2.json.gz`, `energy.json.gz`).

`curl` has robust per-file retry with backoff for 429s, and `load_examples` reads from local filesystem — no network calls to GitHub during the Python load process.

### Files Changed
- `.github/workflows/pre-commit.yml` — nodeenv upgrade
- `superset/config.py` — `pkg_resources` → `importlib.resources`
- `superset/examples/helpers.py` — configurable `BASE_URL` via env var
- `.github/workflows/superset-cli.yml` — curl pre-download + local file serving
- `.github/workflows/bashlib.sh` — curl pre-download for cypress test data

### CI Results
All checks pass ✅