### PR TITLE
Update playwright version in Dockerfile

### DIFF
--- a/aven.Dockerfile
+++ b/aven.Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get install -y libsasl2-dev libldap2-dev libgconf-2-4 libnss3 wget unzip
 RUN pip install "apache-superset[postgres,clickhouse,snowflake,gsheets,gsheets-export]"\
     python-ldap==3.4.4
 
-RUN pip install playwright==1.39.0 && \
+RUN pip install playwright==1.59.1 && \
     playwright install-deps && \
     playwright install chromium
 


### PR DESCRIPTION
### SUMMARY
Updating Playwright version to fix error  [TypeError: (intermediate value).difference is not a function]
<img width="1433" height="328" alt="image" src="https://github.com/user-attachments/assets/85c8f94b-58bc-40a3-9770-842562ccf6a9" />


### TESTING INSTRUCTIONS
Test Dashboard as PNG report to be sent out for dashboards with previous error

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
