### PR TITLE
Bump py playwright version to 1.44.0

### DIFF
--- a/aven.Dockerfile
+++ b/aven.Dockerfile
@@ -13,7 +13,7 @@ RUN /app/.venv/bin/python -m ensurepip --upgrade && \
     /app/.venv/bin/python -m pip install "apache-superset[postgres,clickhouse,snowflake,gsheets,gsheets-export]"\
     python-ldap==3.4.4
 
-RUN /app/.venv/bin/python -m pip install playwright==1.39.0 && \
+RUN /app/.venv/bin/python -m pip install playwright==1.44.0 && \
     playwright install-deps && \
     playwright install chromium
 


### PR DESCRIPTION
Superset v6 introduced usage of Set.prototype.difference() and Set.prototype.union() in the dashboard tab reducer, which are ES2025 features that require Chromium 122+. Our current playwright pin (1.39.0) ships Chromium 119, so the reducer throws `TypeError: ... is not a function` whenever a multi-tab dashboard renders in the report screenshot worker, causing email reports for multi-tab dashboards to fail with screenshot errors. Bumping to playwright 1.44.0 brings Chromium 125, which supports both methods.