### PR TITLE
feat(dashboard): add dashboard review API

### DIFF
--- a/superset/commands/dashboard/review.py
+++ b/superset/commands/dashboard/review.py
@@ -1,0 +1,364 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any
+
+from flask_babel import gettext as _
+from marshmallow import ValidationError
+
+from superset.commands.base import BaseCommand
+from superset.commands.chart.warm_up_cache import ChartWarmUpCacheCommand
+from superset.dashboards.schemas import DashboardJSONMetadataSchema
+from superset.errors import ErrorLevel, SupersetErrorType
+from superset.models.dashboard import Dashboard
+from superset.models.slice import Slice
+from superset.utils import json
+from superset.utils.core import error_msg_from_exception
+
+
+@dataclass(frozen=True)
+class DashboardReviewIssue:
+    message: str
+    level: ErrorLevel
+    error_type: SupersetErrorType
+    path: str | None = None
+    chart_id: int | None = None
+    chart_uuid: str | None = None
+    extra: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "message": self.message,
+            "level": self.level.value,
+            "error_type": self.error_type.value,
+        }
+        if self.path:
+            result["path"] = self.path
+        if self.chart_id is not None:
+            result["chart_id"] = self.chart_id
+        if self.chart_uuid:
+            result["chart_uuid"] = self.chart_uuid
+        if self.extra:
+            result["extra"] = self.extra
+        return result
+
+
+class DashboardReviewCommand(BaseCommand):
+    """
+    Read-only dashboard review for API/MCP consumers.
+
+    The command performs structural checks without running chart queries by default.
+    Runtime chart validation can be enabled with ``run_chart_queries`` and reuses the
+    existing chart cache warm-up command so query errors surface consistently.
+    """
+
+    def __init__(self, dashboard: Dashboard, run_chart_queries: bool = False) -> None:
+        self._dashboard = dashboard
+        self._run_chart_queries = run_chart_queries
+        self._issues: list[DashboardReviewIssue] = []
+        self._chart_results: list[dict[str, Any]] = []
+
+    def run(self) -> dict[str, Any]:
+        self.validate()
+        position = self._load_json_object(
+            self._dashboard.position_json,
+            "position_json",
+            required=False,
+        )
+        metadata = self._load_json_object(
+            self._dashboard.json_metadata,
+            "json_metadata",
+            required=False,
+        )
+
+        if metadata is not None:
+            self._review_metadata(metadata)
+        if position is not None:
+            self._review_position(position)
+
+        self._review_charts()
+        if self._run_chart_queries:
+            self._review_chart_queries()
+
+        return {
+            "dashboard_id": self._dashboard.id,
+            "dashboard_uuid": str(self._dashboard.uuid)
+            if self._dashboard.uuid
+            else None,
+            "dashboard_title": self._dashboard.dashboard_title,
+            "status": self._status,
+            "run_chart_queries": self._run_chart_queries,
+            "chart_count": len(self._dashboard.slices),
+            "issues": [issue.to_dict() for issue in self._issues],
+            "chart_results": self._chart_results,
+        }
+
+    def validate(self) -> None:
+        # The dashboard is access-checked by the API/DAO before this command runs.
+        return None
+
+    @property
+    def _status(self) -> str:
+        if any(issue.level == ErrorLevel.ERROR for issue in self._issues):
+            return "error"
+        if any(issue.level == ErrorLevel.WARNING for issue in self._issues):
+            return "warning"
+        return "pass"
+
+    def _add_issue(
+        self,
+        message: str,
+        level: ErrorLevel,
+        error_type: SupersetErrorType,
+        path: str | None = None,
+        chart: Slice | None = None,
+        chart_id: int | None = None,
+        chart_uuid: str | None = None,
+        extra: dict[str, Any] | None = None,
+    ) -> None:
+        if chart is not None:
+            chart_id = chart.id
+            chart_uuid = str(chart.uuid) if chart.uuid else None
+        self._issues.append(
+            DashboardReviewIssue(
+                message=message,
+                level=level,
+                error_type=error_type,
+                path=path,
+                chart_id=chart_id,
+                chart_uuid=chart_uuid,
+                extra=extra,
+            )
+        )
+
+    def _load_json_object(
+        self,
+        value: str | None,
+        path: str,
+        required: bool,
+    ) -> dict[str, Any] | None:
+        if not value:
+            if required:
+                self._add_issue(
+                    message=_("%(path)s is empty.", path=path),
+                    level=ErrorLevel.ERROR,
+                    error_type=SupersetErrorType.INVALID_PAYLOAD_FORMAT_ERROR,
+                    path=path,
+                )
+            return {}
+
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as ex:
+            self._add_issue(
+                message=_("%(path)s is not valid JSON.", path=path),
+                level=ErrorLevel.ERROR,
+                error_type=SupersetErrorType.INVALID_PAYLOAD_FORMAT_ERROR,
+                path=path,
+                extra={"error": error_msg_from_exception(ex)},
+            )
+            return None
+
+        if not isinstance(parsed, dict):
+            self._add_issue(
+                message=_("%(path)s must be a JSON object.", path=path),
+                level=ErrorLevel.ERROR,
+                error_type=SupersetErrorType.INVALID_PAYLOAD_SCHEMA_ERROR,
+                path=path,
+            )
+            return None
+
+        return parsed
+
+    def _review_metadata(self, metadata: dict[str, Any]) -> None:
+        errors = DashboardJSONMetadataSchema().validate(metadata, partial=False)
+        if errors:
+            self._add_issue(
+                message=_("Dashboard metadata failed schema validation."),
+                level=ErrorLevel.ERROR,
+                error_type=SupersetErrorType.INVALID_PAYLOAD_SCHEMA_ERROR,
+                path="json_metadata",
+                extra={"errors": errors},
+            )
+
+    def _review_position(self, position: dict[str, Any]) -> None:
+        attached_charts_by_id = {chart.id: chart for chart in self._dashboard.slices}
+        referenced_chart_ids: set[int] = set()
+        duplicate_chart_ids: dict[int, list[str]] = defaultdict(list)
+
+        for component_id, component in position.items():
+            if not isinstance(component, dict) or component.get("type") != "CHART":
+                continue
+
+            path = f"position_json.{component_id}.meta"
+            meta = component.get("meta")
+            if not isinstance(meta, dict):
+                self._add_issue(
+                    message=_("Dashboard chart component is missing metadata."),
+                    level=ErrorLevel.ERROR,
+                    error_type=SupersetErrorType.INVALID_PAYLOAD_SCHEMA_ERROR,
+                    path=path,
+                    extra={"component_id": component_id},
+                )
+                continue
+
+            chart_id = meta.get("chartId")
+            chart_uuid = meta.get("uuid")
+            if not isinstance(chart_id, int):
+                self._add_issue(
+                    message=_("Dashboard chart component is missing a valid chart id."),
+                    level=ErrorLevel.ERROR,
+                    error_type=SupersetErrorType.INVALID_PAYLOAD_SCHEMA_ERROR,
+                    path=f"{path}.chartId",
+                    extra={"component_id": component_id},
+                )
+                continue
+
+            referenced_chart_ids.add(chart_id)
+            duplicate_chart_ids[chart_id].append(component_id)
+            chart = attached_charts_by_id.get(chart_id)
+            if chart is None:
+                self._add_issue(
+                    message=_(
+                        "Chart is referenced by the dashboard layout but is not "
+                        "attached to the dashboard."
+                    ),
+                    level=ErrorLevel.ERROR,
+                    error_type=SupersetErrorType.OBJECT_DOES_NOT_EXIST_ERROR,
+                    path=f"{path}.chartId",
+                    chart_id=chart_id,
+                    chart_uuid=str(chart_uuid) if chart_uuid else None,
+                    extra={"component_id": component_id},
+                )
+                continue
+
+            if chart_uuid and str(chart.uuid) != str(chart_uuid):
+                self._add_issue(
+                    message=_(
+                        "Dashboard layout chart UUID does not match the attached "
+                        "chart."
+                    ),
+                    level=ErrorLevel.WARNING,
+                    error_type=SupersetErrorType.INVALID_PAYLOAD_SCHEMA_ERROR,
+                    path=f"{path}.uuid",
+                    chart=chart,
+                    extra={
+                        "component_id": component_id,
+                        "layout_chart_uuid": str(chart_uuid),
+                    },
+                )
+
+        for chart_id, component_ids in duplicate_chart_ids.items():
+            if len(component_ids) > 1:
+                self._add_issue(
+                    message=_("Chart appears multiple times in the dashboard layout."),
+                    level=ErrorLevel.WARNING,
+                    error_type=SupersetErrorType.INVALID_PAYLOAD_SCHEMA_ERROR,
+                    chart_id=chart_id,
+                    extra={"component_ids": component_ids},
+                )
+
+        if not position and self._dashboard.slices:
+            self._add_issue(
+                message=_("Dashboard has attached charts but no layout metadata."),
+                level=ErrorLevel.WARNING,
+                error_type=SupersetErrorType.INVALID_PAYLOAD_SCHEMA_ERROR,
+                path="position_json",
+            )
+
+        for chart in self._dashboard.slices:
+            if chart.id not in referenced_chart_ids:
+                self._add_issue(
+                    message=_(
+                        "Chart is attached to the dashboard but is not present in "
+                        "the layout."
+                    ),
+                    level=ErrorLevel.WARNING,
+                    error_type=SupersetErrorType.INVALID_PAYLOAD_SCHEMA_ERROR,
+                    chart=chart,
+                )
+
+    def _review_charts(self) -> None:
+        for chart in self._dashboard.slices:
+            if not chart.viz_type:
+                self._add_issue(
+                    message=_("Chart is missing a visualization type."),
+                    level=ErrorLevel.ERROR,
+                    error_type=SupersetErrorType.INVALID_PAYLOAD_SCHEMA_ERROR,
+                    path="viz_type",
+                    chart=chart,
+                )
+            if not chart.datasource:
+                self._add_issue(
+                    message=_("Chart datasource does not exist or is not accessible."),
+                    level=ErrorLevel.ERROR,
+                    error_type=SupersetErrorType.OBJECT_DOES_NOT_EXIST_ERROR,
+                    path="datasource",
+                    chart=chart,
+                    extra={
+                        "datasource_id": chart.datasource_id,
+                        "datasource_type": chart.datasource_type,
+                    },
+                )
+            self._review_chart_json(chart, chart.params, "params")
+            self._review_chart_json(chart, chart.query_context, "query_context")
+
+    def _review_chart_json(
+        self,
+        chart: Slice,
+        value: str | None,
+        field_name: str,
+    ) -> None:
+        if not value:
+            return
+        try:
+            json.loads(value)
+        except json.JSONDecodeError as ex:
+            self._add_issue(
+                message=_(
+                    "Chart %(field_name)s is not valid JSON.",
+                    field_name=field_name,
+                ),
+                level=ErrorLevel.ERROR,
+                error_type=SupersetErrorType.INVALID_PAYLOAD_FORMAT_ERROR,
+                path=field_name,
+                chart=chart,
+                extra={"error": error_msg_from_exception(ex)},
+            )
+
+    def _review_chart_queries(self) -> None:
+        for chart in self._dashboard.slices:
+            result = ChartWarmUpCacheCommand(
+                chart,
+                dashboard_id=self._dashboard.id,
+                extra_filters=None,
+            ).run()
+            self._chart_results.append(result)
+            if result.get("viz_error"):
+                self._add_issue(
+                    message=_("Chart query returned an error."),
+                    level=ErrorLevel.ERROR,
+                    error_type=SupersetErrorType.GENERIC_DB_ENGINE_ERROR,
+                    chart=chart,
+                    extra={
+                        "viz_error": result.get("viz_error"),
+                        "viz_status": result.get("viz_status"),
+                    },
+                )

--- a/superset/commands/dashboard/review.py
+++ b/superset/commands/dashboard/review.py
@@ -21,7 +21,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from flask_babel import gettext as _
-from marshmallow import ValidationError
 
 from superset.commands.base import BaseCommand
 from superset.commands.chart.warm_up_cache import ChartWarmUpCacheCommand

--- a/superset/constants.py
+++ b/superset/constants.py
@@ -153,6 +153,7 @@ MODEL_API_RW_METHOD_PERMISSION_MAP = {
     "get_charts": "read",
     "get_datasets": "read",
     "get_tabs": "read",
+    "review": "read",
     "function_names": "read",
     "available": "read",
     "validate_sql": "read",

--- a/superset/dashboards/api.py
+++ b/superset/dashboards/api.py
@@ -55,6 +55,7 @@ from superset.commands.dashboard.export import ExportDashboardsCommand
 from superset.commands.dashboard.fave import AddFavoriteDashboardCommand
 from superset.commands.dashboard.importers.dispatcher import ImportDashboardsCommand
 from superset.commands.dashboard.permalink.create import CreateDashboardPermalinkCommand
+from superset.commands.dashboard.review import DashboardReviewCommand
 from superset.commands.dashboard.unfave import DelFavoriteDashboardCommand
 from superset.commands.dashboard.update import (
     UpdateDashboardColorsConfigCommand,
@@ -89,6 +90,7 @@ from superset.dashboards.schemas import (
     DashboardNativeFiltersConfigUpdateSchema,
     DashboardPostSchema,
     DashboardPutSchema,
+    DashboardReviewResponseSchema,
     DashboardScreenshotPostSchema,
     EmbeddedDashboardConfigSchema,
     EmbeddedDashboardResponseSchema,
@@ -174,6 +176,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         "get_charts",
         "get_datasets",
         "get_tabs",
+        "review",
         "get_embedded",
         "set_embedded",
         "delete_embedded",
@@ -276,6 +279,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
     update_colors_model_schema = DashboardColorsConfigUpdateSchema()
     chart_entity_response_schema = ChartEntityResponseSchema()
     dashboard_get_response_schema = DashboardGetResponseSchema()
+    dashboard_review_response_schema = DashboardReviewResponseSchema()
     dashboard_dataset_schema = DashboardDatasetSchema()
     tab_schema = TabsPayloadSchema()
     embedded_response_schema = EmbeddedDashboardResponseSchema()
@@ -312,6 +316,7 @@ class DashboardRestApi(BaseSupersetModelRestApi):
         DashboardCacheScreenshotResponseSchema,
         DashboardCopySchema,
         DashboardGetResponseSchema,
+        DashboardReviewResponseSchema,
         DashboardDatasetSchema,
         TabsPayloadSchema,
         GetFavStarIdsSchema,
@@ -539,6 +544,63 @@ class DashboardRestApi(BaseSupersetModelRestApi):
             return self.response_403()
         except DashboardNotFoundError:
             return self.response_404()
+
+    @expose("/<id_or_slug>/review/", methods=("GET",))
+    @protect()
+    @safe
+    @statsd_metrics
+    @with_dashboard
+    @event_logger.log_this_with_context(
+        action=lambda self, *args, **kwargs: f"{self.__class__.__name__}.review",
+        log_to_statsd=False,
+    )
+    def review(self, dashboard: Dashboard) -> Response:
+        """Review a dashboard for structural and optional chart query issues.
+        ---
+        get:
+          summary: Review a dashboard for issues.
+          description: >-
+            Returns structured feedback for dashboard automation and MCP clients.
+            Structural checks are read-only. Set run_chart_queries=true to also
+            execute chart cache warm-up checks and include query errors.
+          parameters:
+          - in: path
+            schema:
+              type: string
+            name: id_or_slug
+            description: Either the id of the dashboard, or its slug
+          - in: query
+            schema:
+              type: boolean
+            name: run_chart_queries
+            description: Whether to run chart query validation using cache warm-up.
+          responses:
+            200:
+              description: Dashboard review result
+              content:
+                application/json:
+                  schema:
+                    type: object
+                    properties:
+                      result:
+                        $ref: '#/components/schemas/DashboardReviewResponseSchema'
+            400:
+              $ref: '#/components/responses/400'
+            401:
+              $ref: '#/components/responses/401'
+            403:
+              $ref: '#/components/responses/403'
+            404:
+              $ref: '#/components/responses/404'
+        """
+        run_chart_queries = parse_boolean_string(
+            request.args.get("run_chart_queries", "false")
+        )
+        result = DashboardReviewCommand(
+            dashboard,
+            run_chart_queries=run_chart_queries,
+        ).run()
+        return self.response(200, result=result)
 
     @expose("/", methods=("POST",))
     @protect()

--- a/superset/dashboards/schemas.py
+++ b/superset/dashboards/schemas.py
@@ -250,6 +250,36 @@ class DashboardGetResponseSchema(Schema):
         return serialized
 
 
+class DashboardReviewIssueSchema(Schema):
+    message = fields.String(required=True)
+    level = fields.String(required=True)
+    error_type = fields.String(required=True)
+    path = fields.String(allow_none=True)
+    chart_id = fields.Integer(allow_none=True)
+    chart_uuid = fields.String(allow_none=True)
+    extra = fields.Dict(allow_none=True)
+
+
+class DashboardReviewChartResultSchema(Schema):
+    chart_id = fields.Integer(required=True)
+    viz_error = fields.Raw(allow_none=True)
+    viz_status = fields.Raw(allow_none=True)
+
+
+class DashboardReviewResponseSchema(Schema):
+    dashboard_id = fields.Integer(required=True)
+    dashboard_uuid = fields.String(allow_none=True)
+    dashboard_title = fields.String(required=True)
+    status = fields.String(required=True)
+    run_chart_queries = fields.Boolean(required=True)
+    chart_count = fields.Integer(required=True)
+    issues = fields.List(fields.Nested(DashboardReviewIssueSchema), required=True)
+    chart_results = fields.List(
+        fields.Nested(DashboardReviewChartResultSchema),
+        required=True,
+    )
+
+
 class DatabaseSchema(Schema):
     id = fields.Int()
     name = fields.String()

--- a/tests/integration_tests/dashboards/api_tests.py
+++ b/tests/integration_tests/dashboards/api_tests.py
@@ -505,6 +505,168 @@ class TestDashboardApi(ApiOwnersTestCaseMixin, InsertChartMixin, SupersetTestCas
         data = json.loads(response.data.decode("utf-8"))
         assert data["result"] == []
 
+    def test_review_dashboard(self):
+        """
+        Dashboard API: Test reviewing dashboard metadata and layout.
+        """
+        self.login(ADMIN_USERNAME)
+        admin_id = self.get_user("admin").id
+        chart = self.insert_chart(
+            "review_slice",
+            [admin_id],
+            1,
+            viz_type="table",
+            params="{}",
+        )
+        position_json = json.dumps(
+            {
+                f"CHART-{chart.id}": {
+                    "type": "CHART",
+                    "meta": {
+                        "chartId": chart.id,
+                        "uuid": str(chart.uuid),
+                    },
+                }
+            }
+        )
+        dashboard = self.insert_dashboard(
+            "review_dashboard",
+            "review_dashboard",
+            [admin_id],
+            slices=[chart],
+            position_json=position_json,
+            json_metadata="{}",
+        )
+
+        try:
+            uri = f"api/v1/dashboard/{dashboard.id}/review/"
+            response = self.get_assert_metric(uri, "review")
+            assert response.status_code == 200
+            data = json.loads(response.data.decode("utf-8"))
+            assert data["result"]["status"] == "pass"
+            assert data["result"]["chart_count"] == 1
+            assert data["result"]["issues"] == []
+            assert data["result"]["chart_results"] == []
+        finally:
+            db.session.delete(dashboard)
+            db.session.delete(chart)
+            db.session.commit()
+
+    def test_review_dashboard_flags_layout_chart_not_attached(self):
+        """
+        Dashboard API: Test review flags broken chart references in layout.
+        """
+        self.login(ADMIN_USERNAME)
+        admin_id = self.get_user("admin").id
+        missing_chart_id = self.get_nonexistent_numeric_id(Slice)
+        position_json = json.dumps(
+            {
+                "CHART-missing": {
+                    "type": "CHART",
+                    "meta": {
+                        "chartId": missing_chart_id,
+                        "uuid": "00000000-0000-0000-0000-000000000000",
+                    },
+                }
+            }
+        )
+        dashboard = self.insert_dashboard(
+            "review_dashboard_broken",
+            "review_dashboard_broken",
+            [admin_id],
+            position_json=position_json,
+            json_metadata="{}",
+        )
+
+        try:
+            uri = f"api/v1/dashboard/{dashboard.id}/review/"
+            response = self.get_assert_metric(uri, "review")
+            assert response.status_code == 200
+            data = json.loads(response.data.decode("utf-8"))
+            assert data["result"]["status"] == "error"
+            assert data["result"]["issues"] == [
+                {
+                    "message": (
+                        "Chart is referenced by the dashboard layout but is not "
+                        "attached to the dashboard."
+                    ),
+                    "level": "error",
+                    "error_type": "OBJECT_DOES_NOT_EXIST_ERROR",
+                    "path": "position_json.CHART-missing.meta.chartId",
+                    "chart_id": missing_chart_id,
+                    "chart_uuid": "00000000-0000-0000-0000-000000000000",
+                    "extra": {"component_id": "CHART-missing"},
+                }
+            ]
+        finally:
+            db.session.delete(dashboard)
+            db.session.commit()
+
+    @patch("superset.commands.dashboard.review.ChartWarmUpCacheCommand.run")
+    def test_review_dashboard_with_chart_query_errors(self, warm_up_run_mock):
+        """
+        Dashboard API: Test optional chart query review reports warm-up errors.
+        """
+        self.login(ADMIN_USERNAME)
+        admin_id = self.get_user("admin").id
+        chart = self.insert_chart(
+            "review_query_slice",
+            [admin_id],
+            1,
+            viz_type="table",
+            params="{}",
+        )
+        warm_up_run_mock.return_value = {
+            "chart_id": chart.id,
+            "viz_error": "Query failed",
+            "viz_status": "failed",
+        }
+        position_json = json.dumps(
+            {
+                f"CHART-{chart.id}": {
+                    "type": "CHART",
+                    "meta": {
+                        "chartId": chart.id,
+                        "uuid": str(chart.uuid),
+                    },
+                }
+            }
+        )
+        dashboard = self.insert_dashboard(
+            "review_dashboard_query",
+            "review_dashboard_query",
+            [admin_id],
+            slices=[chart],
+            position_json=position_json,
+            json_metadata="{}",
+        )
+
+        try:
+            uri = f"api/v1/dashboard/{dashboard.id}/review/?run_chart_queries=true"
+            response = self.get_assert_metric(uri, "review")
+            assert response.status_code == 200
+            data = json.loads(response.data.decode("utf-8"))
+            assert data["result"]["status"] == "error"
+            assert data["result"]["run_chart_queries"] is True
+            assert data["result"]["chart_results"] == [warm_up_run_mock.return_value]
+            assert data["result"]["issues"] == [
+                {
+                    "message": "Chart query returned an error.",
+                    "level": "error",
+                    "error_type": "GENERIC_DB_ENGINE_ERROR",
+                    "chart_id": chart.id,
+                    "chart_uuid": str(chart.uuid),
+                    "extra": {
+                        "viz_error": "Query failed",
+                        "viz_status": "failed",
+                    },
+                }
+            ]
+        finally:
+            db.session.delete(dashboard)
+            db.session.delete(chart)
+            db.session.commit()
+
     def test_get_dashboard(self):
         """
         Dashboard API: Test get dashboard


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### SUMMARY
Adds a read-only dashboard review capability for automation/MCP clients. The new `GET /api/v1/dashboard/{id_or_slug}/review/` endpoint returns structured issue feedback for dashboard metadata, layout/chart attachment consistency, chart datasource presence, and chart JSON validity. Callers can opt into runtime chart query checks with `run_chart_queries=true`, which reuses existing chart cache warm-up behavior to surface query errors.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Not applicable; API-only change.

### TESTING INSTRUCTIONS
- `python3 -m compileall -q superset/commands/dashboard/review.py superset/dashboards/api.py superset/dashboards/schemas.py tests/integration_tests/dashboards/api_tests.py`
- Blocked in this Cloud Agent image: `python3 -m pytest ...` because `pytest` is not installed.
- Blocked in this Cloud Agent image: `pre-commit run` because `pre-commit` is not installed.

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c127c6a-5e93-448f-a56c-1d6a4bd94cf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c127c6a-5e93-448f-a56c-1d6a4bd94cf4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

