### PR TITLE
feat(dashboards): add REST automation utility

### DIFF
--- a/superset-dashboards/README.md
+++ b/superset-dashboards/README.md
@@ -1,0 +1,111 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Superset Dashboard Automation
+
+This directory contains a deterministic, REST API driven dashboard deployer for
+version-controlled Superset dashboard specs.
+
+The runtime path is intentionally plain HTTP:
+
+```text
+YAML in git -> python deploy.py -> Superset REST API -> Superset instance
+```
+
+MCP or LLM tools can still help authors generate chart params or dashboard
+layouts, but their output should be committed as static YAML/JSON and reviewed
+before deployment.
+
+## Spec format
+
+Start with `dashboards/loan_ops_overview.yaml`. A spec contains:
+
+- `database`: Superset database connection metadata.
+- `dataset`: table or virtual dataset metadata.
+- `dashboard`: title, slug, publishing state, metadata, and optional
+  `position_json`/`position` template.
+- `charts`: saved charts with `slice_name`, `viz_type`, and Explore `params`.
+
+Use placeholders instead of environment-specific IDs:
+
+- `__DATASET_ID__` becomes `<dataset id>__table` for chart params.
+- `__DATASET_ID_INT__` becomes the numeric dataset ID.
+- `__CHART_ID__` or `__CHART_ID:<slice_name>__` can be used in supplied
+  dashboard layout templates.
+
+If no dashboard layout is supplied, the deployer generates a deterministic
+one-chart-per-row `position_json`.
+
+## Required environment variables
+
+```bash
+export SUPERSET_BASE_URL="https://superset.example.com"
+export SUPERSET_USERNAME="service-account"
+export SUPERSET_PASSWORD="..."
+export SUPERSET_DB_URI="postgresql+psycopg2://user:pass@host:5432/database"
+```
+
+`SUPERSET_DB_URI` overrides `database.sqlalchemy_uri` so secrets do not need to
+be committed.
+
+## Test sequence
+
+From this directory:
+
+```bash
+# A) Dry run
+python3 deploy.py \
+  --spec dashboards/loan_ops_overview.yaml \
+  --base-url "$SUPERSET_BASE_URL" \
+  --username "$SUPERSET_USERNAME" \
+  --password "$SUPERSET_PASSWORD" \
+  --database-sqlalchemy-uri "$SUPERSET_DB_URI" \
+  --dry-run
+
+# B) Real deploy
+python3 deploy.py \
+  --spec dashboards/loan_ops_overview.yaml \
+  --base-url "$SUPERSET_BASE_URL" \
+  --username "$SUPERSET_USERNAME" \
+  --password "$SUPERSET_PASSWORD" \
+  --database-sqlalchemy-uri "$SUPERSET_DB_URI"
+
+# C) Smoke checks only
+python3 deploy.py \
+  --spec dashboards/loan_ops_overview.yaml \
+  --base-url "$SUPERSET_BASE_URL" \
+  --username "$SUPERSET_USERNAME" \
+  --password "$SUPERSET_PASSWORD" \
+  --database-sqlalchemy-uri "$SUPERSET_DB_URI" \
+  --skip-upsert \
+  --run-smoke-tests
+```
+
+Run the real deploy twice to verify idempotency. Existing databases, charts, and
+dashboards are looked up before writes; datasets use Superset's
+`/api/v1/dataset/get_or_create/` endpoint.
+
+## Rollback snapshots
+
+Before mutating an existing dashboard, the deployer exports a ZIP snapshot via
+`/api/v1/dashboard/export/` into `.superset-dashboard-snapshots/`. If a write
+fails and rollback is enabled, it imports that ZIP back through
+`/api/v1/dashboard/import/` with `overwrite=true`.
+
+Store these ZIPs as CI artifacts for production deployments.

--- a/superset-dashboards/dashboards/loan_ops_overview.yaml
+++ b/superset-dashboards/dashboards/loan_ops_overview.yaml
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+database:
+  database_name: "staging_analytics"
+  sqlalchemy_uri: "postgresql+psycopg2://username:password@host:5432/database"
+  configuration_method: "sqlalchemy_form"
+  expose_in_sqllab: true
+
+dataset:
+  schema: "public"
+  table_name: "loan_applications"
+
+dashboard:
+  title: "Staging - Automation Smoke Test"
+  slug: "staging-automation-smoke-test"
+  published: false
+  metadata:
+    timed_refresh_immune_slices: []
+    expanded_slices: {}
+    refresh_frequency: 0
+    default_filters: "{}"
+
+charts:
+  - slice_name: "Smoke - Latest Rows"
+    viz_type: "table"
+    params:
+      datasource: "__DATASET_ID__"
+      viz_type: "table"
+      all_columns:
+        - "id"
+        - "status"
+        - "created_at"
+      row_limit: 50
+      order_desc: true

--- a/superset-dashboards/deploy.py
+++ b/superset-dashboards/deploy.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from superset_dashboards.cli import main
+
+
+if __name__ == "__main__":
+    main()

--- a/superset-dashboards/deploy.py
+++ b/superset-dashboards/deploy.py
@@ -17,6 +17,5 @@
 # under the License.
 from superset_dashboards.cli import main
 
-
 if __name__ == "__main__":
     main()

--- a/superset-dashboards/superset_dashboards/__init__.py
+++ b/superset-dashboards/superset_dashboards/__init__.py
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Utilities for REST API driven Superset dashboard automation."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/superset-dashboards/superset_dashboards/cli.py
+++ b/superset-dashboards/superset_dashboards/cli.py
@@ -70,7 +70,9 @@ from superset_dashboards.spec import load_spec
     show_default=True,
     help="HTTP timeout in seconds.",
 )
-@click.option("--dry-run", is_flag=True, help="Plan the deploy without mutating Superset.")
+@click.option(
+    "--dry-run", is_flag=True, help="Plan the deploy without mutating Superset."
+)
 @click.option(
     "--skip-upsert",
     is_flag=True,

--- a/superset-dashboards/superset_dashboards/cli.py
+++ b/superset-dashboards/superset_dashboards/cli.py
@@ -1,0 +1,132 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from superset_dashboards.client import SupersetApiClient
+from superset_dashboards.deployer import DashboardDeployer
+from superset_dashboards.spec import load_spec
+
+
+@click.command()
+@click.option(
+    "--spec",
+    "spec_path",
+    required=True,
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    help="Path to a dashboard automation YAML spec.",
+)
+@click.option(
+    "--base-url",
+    required=True,
+    envvar="SUPERSET_BASE_URL",
+    help="Base URL for the target Superset instance.",
+)
+@click.option(
+    "--username",
+    required=True,
+    envvar="SUPERSET_USERNAME",
+    help="Superset service account username.",
+)
+@click.option(
+    "--password",
+    required=True,
+    envvar="SUPERSET_PASSWORD",
+    help="Superset service account password.",
+)
+@click.option(
+    "--database-sqlalchemy-uri",
+    envvar="SUPERSET_DB_URI",
+    help="Override database.sqlalchemy_uri from the spec, keeping secrets out of git.",
+)
+@click.option(
+    "--snapshot-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path(".superset-dashboard-snapshots"),
+    show_default=True,
+    help="Directory where pre-deploy dashboard export ZIPs are stored.",
+)
+@click.option(
+    "--timeout",
+    type=float,
+    default=30.0,
+    show_default=True,
+    help="HTTP timeout in seconds.",
+)
+@click.option("--dry-run", is_flag=True, help="Plan the deploy without mutating Superset.")
+@click.option(
+    "--skip-upsert",
+    is_flag=True,
+    help="Skip all creates/updates; useful with --run-smoke-tests.",
+)
+@click.option(
+    "--run-smoke-tests",
+    is_flag=True,
+    help="Check the dashboard and saved chart data endpoints after resolving assets.",
+)
+@click.option(
+    "--no-rollback",
+    is_flag=True,
+    help="Do not re-import the pre-deploy snapshot if a write fails.",
+)
+def main(
+    spec_path: Path,
+    base_url: str,
+    username: str,
+    password: str,
+    database_sqlalchemy_uri: str | None,
+    snapshot_dir: Path,
+    timeout: float,
+    dry_run: bool,
+    skip_upsert: bool,
+    run_smoke_tests: bool,
+    no_rollback: bool,
+) -> None:
+    """Deploy a version-controlled dashboard spec through Superset's REST API."""
+
+    spec = load_spec(spec_path, database_sqlalchemy_uri=database_sqlalchemy_uri)
+    client = SupersetApiClient(
+        base_url,
+        username,
+        password,
+        timeout=timeout,
+    )
+    client.authenticate()
+
+    deployer = DashboardDeployer(
+        client,
+        dry_run=dry_run,
+        skip_upsert=skip_upsert,
+        run_smoke_tests=run_smoke_tests,
+        snapshot_dir=snapshot_dir,
+        rollback_on_failure=not no_rollback,
+    )
+    result = deployer.deploy(spec)
+
+    for action in result.actions:
+        click.echo(action)
+    if result.snapshot_path:
+        click.echo(f"Snapshot: {result.snapshot_path}")
+    if result.dashboard_id is not None:
+        click.echo(f"Dashboard ID: {result.dashboard_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/superset-dashboards/superset_dashboards/client.py
+++ b/superset-dashboards/superset_dashboards/client.py
@@ -177,7 +177,9 @@ class SupersetApiClient:
             ],
             "page_size": 2,
         }
-        payload = self.get_json(f"/api/v1/{resource}/", params={"q": prison.dumps(query)})
+        payload = self.get_json(
+            f"/api/v1/{resource}/", params={"q": prison.dumps(query)}
+        )
         result = payload.get("result", {})
         if isinstance(result, dict):
             data = result.get("data", [])

--- a/superset-dashboards/superset_dashboards/client.py
+++ b/superset-dashboards/superset_dashboards/client.py
@@ -1,0 +1,233 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Literal
+from urllib.parse import urljoin
+
+import prison
+import requests
+from requests import Response, Session
+
+
+class SupersetApiError(RuntimeError):
+    """Raised when Superset returns a non-success API response."""
+
+    def __init__(self, message: str, response: Response | None = None) -> None:
+        super().__init__(message)
+        self.response = response
+
+
+class SupersetApiClient:
+    """Small session-aware client for Superset's current REST API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        username: str,
+        password: str,
+        *,
+        timeout: float = 30.0,
+        verify: bool | str = True,
+    ) -> None:
+        self.base_url = base_url.rstrip("/") + "/"
+        self.username = username
+        self.password = password
+        self.timeout = timeout
+        self.verify = verify
+        self.session: Session = requests.Session()
+        self.csrf_token: str | None = None
+
+    def authenticate(self) -> None:
+        """Authenticate with browser-session login and fetch a CSRF token."""
+
+        response = self.session.post(
+            self.url("/login/"),
+            data={
+                "username": self.username,
+                "password": self.password,
+                "provider": "db",
+            },
+            allow_redirects=False,
+            timeout=self.timeout,
+            verify=self.verify,
+        )
+        if response.status_code < 200 or response.status_code >= 400:
+            raise SupersetApiError(
+                f"Superset login failed: {self._response_message(response)}",
+                response,
+            )
+
+        csrf_response = self.get_json("/api/v1/security/csrf_token/")
+        token = csrf_response.get("result")
+        if not isinstance(token, str) or not token:
+            raise SupersetApiError("Superset did not return a CSRF token")
+        self.csrf_token = token
+
+    def url(self, endpoint: str) -> str:
+        """Return an absolute URL for a Superset endpoint."""
+
+        return urljoin(self.base_url, endpoint.lstrip("/"))
+
+    def request(
+        self,
+        method: Literal["GET", "POST", "PUT", "DELETE"],
+        endpoint: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+        params: dict[str, Any] | None = None,
+        data: dict[str, Any] | None = None,
+        files: dict[str, Any] | None = None,
+        expect_json: bool = True,
+    ) -> dict[str, Any] | bytes:
+        """Send a request and return decoded JSON or raw bytes."""
+
+        headers = {"Accept": "application/json"}
+        if method in {"POST", "PUT", "DELETE"} and self.csrf_token:
+            headers["X-CSRFToken"] = self.csrf_token
+
+        response = self.session.request(
+            method,
+            self.url(endpoint),
+            json=json_body,
+            params=params,
+            data=data,
+            files=files,
+            headers=headers,
+            timeout=self.timeout,
+            verify=self.verify,
+        )
+        if response.status_code < 200 or response.status_code >= 300:
+            raise SupersetApiError(
+                f"{method} {endpoint} failed: {self._response_message(response)}",
+                response,
+            )
+
+        if not expect_json:
+            return response.content
+        try:
+            payload = response.json()
+        except ValueError as ex:
+            raise SupersetApiError(
+                f"{method} {endpoint} did not return JSON",
+                response,
+            ) from ex
+        if not isinstance(payload, dict):
+            raise SupersetApiError(
+                f"{method} {endpoint} returned an unexpected JSON payload",
+                response,
+            )
+        return payload
+
+    def get_json(
+        self,
+        endpoint: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Send a GET request and return a JSON object."""
+
+        return self.request("GET", endpoint, params=params)  # type: ignore[return-value]
+
+    def post_json(
+        self,
+        endpoint: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Send a POST request and return a JSON object."""
+
+        return self.request("POST", endpoint, json_body=payload)  # type: ignore[return-value]
+
+    def put_json(
+        self,
+        endpoint: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Send a PUT request and return a JSON object."""
+
+        return self.request("PUT", endpoint, json_body=payload)  # type: ignore[return-value]
+
+    def find_one(
+        self,
+        resource: Literal["database", "dataset", "chart", "dashboard"],
+        filters: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Find zero or one resource by exact-match API filters."""
+
+        query = {
+            "filters": [
+                {"col": col, "opr": "eq", "value": value}
+                for col, value in filters.items()
+                if value is not None
+            ],
+            "page_size": 2,
+        }
+        payload = self.get_json(f"/api/v1/{resource}/", params={"q": prison.dumps(query)})
+        result = payload.get("result", {})
+        if isinstance(result, dict):
+            data = result.get("data", [])
+        else:
+            data = result
+        if not isinstance(data, list):
+            raise SupersetApiError(
+                f"Unexpected list payload while looking up {resource}: {payload}"
+            )
+        if len(data) > 1:
+            raise SupersetApiError(f"Multiple {resource} rows matched {filters}")
+        return data[0] if data else None
+
+    def export_dashboard(self, dashboard_id: int, output_path: Path) -> Path:
+        """Export a dashboard ZIP snapshot to disk."""
+
+        query = prison.dumps([dashboard_id])
+        content = self.request(
+            "GET",
+            "/api/v1/dashboard/export/",
+            params={"q": query},
+            expect_json=False,
+        )
+        if not isinstance(content, bytes):
+            raise SupersetApiError("Dashboard export returned an unexpected payload")
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(content)
+        return output_path
+
+    def import_dashboard_zip(self, zip_path: Path, *, overwrite: bool = True) -> None:
+        """Import a dashboard ZIP snapshot, optionally overwriting existing assets."""
+
+        with zip_path.open("rb") as file_obj:
+            self.request(
+                "POST",
+                "/api/v1/dashboard/import/",
+                data={"overwrite": "true" if overwrite else "false"},
+                files={"formData": file_obj},
+            )
+
+    def health(self) -> dict[str, Any] | bytes:
+        """Return the Superset health endpoint response."""
+
+        return self.request("GET", "/health", expect_json=False)
+
+    @staticmethod
+    def _response_message(response: Response) -> str:
+        try:
+            payload = response.json()
+        except ValueError:
+            return response.text
+        return str(payload)

--- a/superset-dashboards/superset_dashboards/deployer.py
+++ b/superset-dashboards/superset_dashboards/deployer.py
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal, Protocol
 
-from superset_dashboards.layout import ChartLayout, build_dashboard_position
+from superset_dashboards.layout import build_dashboard_position, ChartLayout
 from superset_dashboards.spec import (
     ensure_json_string,
     pick_fields,
@@ -48,7 +48,9 @@ class SupersetClientProtocol(Protocol):
     def put_json(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
         """PUT JSON to Superset."""
 
-    def get_json(self, endpoint: str, *, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    def get_json(
+        self, endpoint: str, *, params: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """GET JSON from Superset."""
 
     def export_dashboard(self, dashboard_id: int, output_path: Path) -> Path:
@@ -163,9 +165,15 @@ class DashboardDeployer:
         try:
             database_id = self._upsert_database(spec["database"])
             dataset_id = self._upsert_dataset(spec["dataset"], database_id)
-            dashboard_id = self._upsert_dashboard_shell(spec["dashboard"], existing_dashboard)
-            chart_layouts = self._upsert_charts(spec["charts"], dataset_id, dashboard_id)
-            self._update_dashboard_position(spec["dashboard"], dashboard_id, chart_layouts)
+            dashboard_id = self._upsert_dashboard_shell(
+                spec["dashboard"], existing_dashboard
+            )
+            chart_layouts = self._upsert_charts(
+                spec["charts"], dataset_id, dashboard_id
+            )
+            self._update_dashboard_position(
+                spec["dashboard"], dashboard_id, chart_layouts
+            )
 
             if self.run_smoke_tests:
                 self._run_smoke_tests()
@@ -191,10 +199,14 @@ class DashboardDeployer:
             return
 
         timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-        slug = existing_dashboard.get("slug") or existing_dashboard.get("dashboard_title")
+        slug = existing_dashboard.get("slug") or existing_dashboard.get(
+            "dashboard_title"
+        )
         safe_name = stable_suffix(str(slug or dashboard_id))
         output_path = self.snapshot_dir / f"{safe_name}-{timestamp}.zip"
-        self.result.snapshot_path = self.client.export_dashboard(dashboard_id, output_path)
+        self.result.snapshot_path = self.client.export_dashboard(
+            dashboard_id, output_path
+        )
         self._record(f"Exported pre-deploy dashboard snapshot to {output_path}")
 
     def _upsert_database(self, database: dict[str, Any]) -> int:
@@ -207,7 +219,9 @@ class DashboardDeployer:
         )
         if existing:
             database_id = int(existing["id"])
-            self._record(f"Updating database {database['database_name']} ({database_id})")
+            self._record(
+                f"Updating database {database['database_name']} ({database_id})"
+            )
             if not self.dry_run:
                 self.client.put_json(f"/api/v1/database/{database_id}", payload)
             self.result.database_id = database_id
@@ -241,7 +255,9 @@ class DashboardDeployer:
             "/api/v1/dataset/get_or_create/",
             {key: value for key, value in lookup_payload.items() if value is not None},
         )
-        dataset_id = int(response.get("result", {}).get("table_id") or self._extract_id(response))
+        dataset_id = int(
+            response.get("result", {}).get("table_id") or self._extract_id(response)
+        )
         self.client.put_json(f"/api/v1/dataset/{dataset_id}", payload)
         self.result.dataset_id = dataset_id
         return dataset_id
@@ -255,7 +271,9 @@ class DashboardDeployer:
         payload.setdefault("position_json", "{}")
         if existing_dashboard:
             dashboard_id = int(existing_dashboard["id"])
-            self._record(f"Updating dashboard shell {title_from_dashboard_spec(dashboard)}")
+            self._record(
+                f"Updating dashboard shell {title_from_dashboard_spec(dashboard)}"
+            )
             if not self.dry_run:
                 self.client.put_json(f"/api/v1/dashboard/{dashboard_id}", payload)
             self.result.dashboard_id = dashboard_id
@@ -304,7 +322,9 @@ class DashboardDeployer:
                     response = self.client.post_json("/api/v1/chart/", payload)
                     result = response.get("result", {})
                     chart_id = self._extract_id(response)
-                    chart_uuid = result.get("uuid") if isinstance(result, dict) else None
+                    chart_uuid = (
+                        result.get("uuid") if isinstance(result, dict) else None
+                    )
 
             self.result.chart_ids[chart["slice_name"]] = chart_id
             chart_layouts.append(
@@ -324,7 +344,9 @@ class DashboardDeployer:
         dashboard_id: int,
         chart_layouts: list[ChartLayout],
     ) -> None:
-        chart_ids_by_name = {chart.slice_name: chart.chart_id for chart in chart_layouts}
+        chart_ids_by_name = {
+            chart.slice_name: chart.chart_id for chart in chart_layouts
+        }
         supplied_position = dashboard.get("position_json", dashboard.get("position"))
         position = supplied_position or build_dashboard_position(chart_layouts)
         position = substitute_chart_placeholders(position, chart_ids_by_name)
@@ -353,7 +375,9 @@ class DashboardDeployer:
         spec: dict[str, Any],
         existing_dashboard: dict[str, Any] | None,
     ) -> None:
-        database = self._find_by_uuid_or_name("database", spec["database"], "database_name")
+        database = self._find_by_uuid_or_name(
+            "database", spec["database"], "database_name"
+        )
         dataset = self._find_by_uuid_or_name("dataset", spec["dataset"], "table_name")
         if existing_dashboard:
             self.result.dashboard_id = int(existing_dashboard["id"])

--- a/superset-dashboards/superset_dashboards/deployer.py
+++ b/superset-dashboards/superset_dashboards/deployer.py
@@ -1,0 +1,425 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal, Protocol
+
+from superset_dashboards.layout import ChartLayout, build_dashboard_position
+from superset_dashboards.spec import (
+    ensure_json_string,
+    pick_fields,
+    stable_suffix,
+    substitute_chart_placeholders,
+    substitute_dataset_placeholders,
+    title_from_dashboard_spec,
+)
+
+
+class SupersetClientProtocol(Protocol):
+    """Protocol implemented by the REST client and tests' fake clients."""
+
+    def find_one(
+        self,
+        resource: Literal["database", "dataset", "chart", "dashboard"],
+        filters: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Find a single resource."""
+
+    def post_json(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """POST JSON to Superset."""
+
+    def put_json(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """PUT JSON to Superset."""
+
+    def get_json(self, endpoint: str, *, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """GET JSON from Superset."""
+
+    def export_dashboard(self, dashboard_id: int, output_path: Path) -> Path:
+        """Export a dashboard snapshot."""
+
+    def import_dashboard_zip(self, zip_path: Path, *, overwrite: bool = True) -> None:
+        """Import a dashboard snapshot."""
+
+
+@dataclass
+class DeploymentResult:
+    """Summary of a dashboard automation deployment."""
+
+    actions: list[str] = field(default_factory=list)
+    database_id: int | None = None
+    dataset_id: int | None = None
+    dashboard_id: int | None = None
+    chart_ids: dict[str, int] = field(default_factory=dict)
+    snapshot_path: Path | None = None
+
+
+class DashboardDeployer:
+    """Deploy a YAML dashboard spec through Superset's REST API."""
+
+    DATABASE_FIELDS = {
+        "database_name",
+        "sqlalchemy_uri",
+        "configuration_method",
+        "cache_timeout",
+        "expose_in_sqllab",
+        "allow_run_async",
+        "allow_file_upload",
+        "allow_ctas",
+        "allow_cvas",
+        "allow_dml",
+        "extra",
+        "uuid",
+        "is_managed_externally",
+        "external_url",
+    }
+    DATASET_FIELDS = {
+        "table_name",
+        "catalog",
+        "schema",
+        "sql",
+        "owners",
+        "normalize_columns",
+        "always_filter_main_dttm",
+        "template_params",
+        "uuid",
+        "is_managed_externally",
+        "external_url",
+    }
+    CHART_FIELDS = {
+        "slice_name",
+        "description",
+        "viz_type",
+        "owners",
+        "params",
+        "query_context",
+        "cache_timeout",
+        "certified_by",
+        "certification_details",
+        "is_managed_externally",
+        "external_url",
+        "uuid",
+    }
+    DASHBOARD_FIELDS = {
+        "slug",
+        "owners",
+        "roles",
+        "css",
+        "theme_id",
+        "published",
+        "certified_by",
+        "certification_details",
+        "is_managed_externally",
+        "external_url",
+        "uuid",
+    }
+
+    def __init__(
+        self,
+        client: SupersetClientProtocol,
+        *,
+        dry_run: bool = False,
+        skip_upsert: bool = False,
+        run_smoke_tests: bool = False,
+        snapshot_dir: Path | None = None,
+        rollback_on_failure: bool = True,
+    ) -> None:
+        self.client = client
+        self.dry_run = dry_run
+        self.skip_upsert = skip_upsert
+        self.run_smoke_tests = run_smoke_tests
+        self.snapshot_dir = snapshot_dir
+        self.rollback_on_failure = rollback_on_failure
+        self.result = DeploymentResult()
+
+    def deploy(self, spec: dict[str, Any]) -> DeploymentResult:
+        """Deploy or validate a dashboard automation spec."""
+
+        existing_dashboard = self._find_dashboard(spec["dashboard"])
+        if self.skip_upsert:
+            self._record("Skipping upsert phase")
+            self._resolve_existing_assets(spec, existing_dashboard)
+            if self.run_smoke_tests:
+                self._run_smoke_tests()
+            return self.result
+
+        self._snapshot_existing_dashboard(existing_dashboard)
+        try:
+            database_id = self._upsert_database(spec["database"])
+            dataset_id = self._upsert_dataset(spec["dataset"], database_id)
+            dashboard_id = self._upsert_dashboard_shell(spec["dashboard"], existing_dashboard)
+            chart_layouts = self._upsert_charts(spec["charts"], dataset_id, dashboard_id)
+            self._update_dashboard_position(spec["dashboard"], dashboard_id, chart_layouts)
+
+            if self.run_smoke_tests:
+                self._run_smoke_tests()
+        except Exception:
+            self._rollback()
+            raise
+
+        return self.result
+
+    def _snapshot_existing_dashboard(
+        self,
+        existing_dashboard: dict[str, Any] | None,
+    ) -> None:
+        if not existing_dashboard:
+            self._record("No existing dashboard snapshot needed")
+            return
+        dashboard_id = int(existing_dashboard["id"])
+        if self.dry_run:
+            self._record(f"Would export dashboard {dashboard_id} before writes")
+            return
+        if not self.snapshot_dir:
+            self._record("No snapshot directory configured; skipping snapshot export")
+            return
+
+        timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        slug = existing_dashboard.get("slug") or existing_dashboard.get("dashboard_title")
+        safe_name = stable_suffix(str(slug or dashboard_id))
+        output_path = self.snapshot_dir / f"{safe_name}-{timestamp}.zip"
+        self.result.snapshot_path = self.client.export_dashboard(dashboard_id, output_path)
+        self._record(f"Exported pre-deploy dashboard snapshot to {output_path}")
+
+    def _upsert_database(self, database: dict[str, Any]) -> int:
+        payload = pick_fields(database, self.DATABASE_FIELDS)
+        payload.setdefault("configuration_method", "sqlalchemy_form")
+        existing = self._find_by_uuid_or_name(
+            "database",
+            database,
+            "database_name",
+        )
+        if existing:
+            database_id = int(existing["id"])
+            self._record(f"Updating database {database['database_name']} ({database_id})")
+            if not self.dry_run:
+                self.client.put_json(f"/api/v1/database/{database_id}", payload)
+            self.result.database_id = database_id
+            return database_id
+
+        self._record(f"Creating database {database['database_name']}")
+        if self.dry_run:
+            self.result.database_id = 0
+            return 0
+        response = self.client.post_json("/api/v1/database/", payload)
+        database_id = self._extract_id(response)
+        self.result.database_id = database_id
+        return database_id
+
+    def _upsert_dataset(self, dataset: dict[str, Any], database_id: int) -> int:
+        payload = pick_fields(dataset, self.DATASET_FIELDS)
+        payload["database_id"] = database_id
+
+        lookup_payload = {
+            "database_id": database_id,
+            "table_name": dataset["table_name"],
+            "catalog": dataset.get("catalog"),
+            "schema": dataset.get("schema"),
+        }
+        self._record(f"Resolving dataset {dataset['table_name']}")
+        if self.dry_run:
+            self.result.dataset_id = 0
+            return 0
+
+        response = self.client.post_json(
+            "/api/v1/dataset/get_or_create/",
+            {key: value for key, value in lookup_payload.items() if value is not None},
+        )
+        dataset_id = int(response.get("result", {}).get("table_id") or self._extract_id(response))
+        self.client.put_json(f"/api/v1/dataset/{dataset_id}", payload)
+        self.result.dataset_id = dataset_id
+        return dataset_id
+
+    def _upsert_dashboard_shell(
+        self,
+        dashboard: dict[str, Any],
+        existing_dashboard: dict[str, Any] | None,
+    ) -> int:
+        payload = self._dashboard_payload(dashboard)
+        payload.setdefault("position_json", "{}")
+        if existing_dashboard:
+            dashboard_id = int(existing_dashboard["id"])
+            self._record(f"Updating dashboard shell {title_from_dashboard_spec(dashboard)}")
+            if not self.dry_run:
+                self.client.put_json(f"/api/v1/dashboard/{dashboard_id}", payload)
+            self.result.dashboard_id = dashboard_id
+            return dashboard_id
+
+        self._record(f"Creating dashboard shell {title_from_dashboard_spec(dashboard)}")
+        if self.dry_run:
+            self.result.dashboard_id = 0
+            return 0
+        response = self.client.post_json("/api/v1/dashboard/", payload)
+        dashboard_id = self._extract_id(response)
+        self.result.dashboard_id = dashboard_id
+        return dashboard_id
+
+    def _upsert_charts(
+        self,
+        charts: list[dict[str, Any]],
+        dataset_id: int,
+        dashboard_id: int,
+    ) -> list[ChartLayout]:
+        chart_layouts: list[ChartLayout] = []
+        for chart in charts:
+            payload = pick_fields(chart, self.CHART_FIELDS)
+            payload["datasource_id"] = dataset_id
+            payload["datasource_type"] = "table"
+            payload["dashboards"] = [dashboard_id]
+            payload["params"] = ensure_json_string(
+                substitute_dataset_placeholders(chart.get("params", {}), dataset_id)
+            )
+            if chart.get("query_context") is not None:
+                payload["query_context"] = ensure_json_string(chart["query_context"])
+
+            existing = self._find_by_uuid_or_name("chart", chart, "slice_name")
+            if existing:
+                chart_id = int(existing["id"])
+                chart_uuid = existing.get("uuid")
+                self._record(f"Updating chart {chart['slice_name']} ({chart_id})")
+                if not self.dry_run:
+                    self.client.put_json(f"/api/v1/chart/{chart_id}", payload)
+            else:
+                self._record(f"Creating chart {chart['slice_name']}")
+                if self.dry_run:
+                    chart_id = 0
+                    chart_uuid = chart.get("uuid")
+                else:
+                    response = self.client.post_json("/api/v1/chart/", payload)
+                    result = response.get("result", {})
+                    chart_id = self._extract_id(response)
+                    chart_uuid = result.get("uuid") if isinstance(result, dict) else None
+
+            self.result.chart_ids[chart["slice_name"]] = chart_id
+            chart_layouts.append(
+                ChartLayout(
+                    chart_id=chart_id,
+                    slice_name=chart["slice_name"],
+                    uuid=str(chart_uuid) if chart_uuid else None,
+                    width=int(chart.get("width", 12)),
+                    height=int(chart.get("height", 50)),
+                )
+            )
+        return chart_layouts
+
+    def _update_dashboard_position(
+        self,
+        dashboard: dict[str, Any],
+        dashboard_id: int,
+        chart_layouts: list[ChartLayout],
+    ) -> None:
+        chart_ids_by_name = {chart.slice_name: chart.chart_id for chart in chart_layouts}
+        supplied_position = dashboard.get("position_json", dashboard.get("position"))
+        position = supplied_position or build_dashboard_position(chart_layouts)
+        position = substitute_chart_placeholders(position, chart_ids_by_name)
+        payload = self._dashboard_payload(dashboard, position=position)
+        self._record(f"Updating dashboard layout for dashboard {dashboard_id}")
+        if not self.dry_run:
+            self.client.put_json(f"/api/v1/dashboard/{dashboard_id}", payload)
+
+    def _dashboard_payload(
+        self,
+        dashboard: dict[str, Any],
+        *,
+        position: Any | None = None,
+    ) -> dict[str, Any]:
+        payload = pick_fields(dashboard, self.DASHBOARD_FIELDS)
+        payload["dashboard_title"] = title_from_dashboard_spec(dashboard)
+        payload.setdefault("is_managed_externally", True)
+        metadata = dashboard.get("json_metadata", dashboard.get("metadata", {}))
+        payload["json_metadata"] = ensure_json_string(metadata)
+        if position is not None:
+            payload["position_json"] = ensure_json_string(position)
+        return payload
+
+    def _resolve_existing_assets(
+        self,
+        spec: dict[str, Any],
+        existing_dashboard: dict[str, Any] | None,
+    ) -> None:
+        database = self._find_by_uuid_or_name("database", spec["database"], "database_name")
+        dataset = self._find_by_uuid_or_name("dataset", spec["dataset"], "table_name")
+        if existing_dashboard:
+            self.result.dashboard_id = int(existing_dashboard["id"])
+        if database:
+            self.result.database_id = int(database["id"])
+        if dataset:
+            self.result.dataset_id = int(dataset["id"])
+        for chart in spec["charts"]:
+            existing_chart = self._find_by_uuid_or_name("chart", chart, "slice_name")
+            if existing_chart:
+                self.result.chart_ids[chart["slice_name"]] = int(existing_chart["id"])
+
+    def _run_smoke_tests(self) -> None:
+        if self.result.dashboard_id is None:
+            raise RuntimeError("Cannot smoke-test without a dashboard ID")
+
+        self._record(f"Smoke-testing dashboard {self.result.dashboard_id}")
+        self.client.get_json(f"/api/v1/dashboard/{self.result.dashboard_id}")
+        for slice_name, chart_id in self.result.chart_ids.items():
+            self._record(f"Smoke-testing chart {slice_name} ({chart_id})")
+            self.client.get_json(f"/api/v1/chart/{chart_id}/data/")
+
+    def _rollback(self) -> None:
+        if not self.rollback_on_failure or not self.result.snapshot_path:
+            return
+        self._record(f"Rolling back from snapshot {self.result.snapshot_path}")
+        self.client.import_dashboard_zip(self.result.snapshot_path, overwrite=True)
+
+    def _find_dashboard(self, dashboard: dict[str, Any]) -> dict[str, Any] | None:
+        if dashboard.get("uuid"):
+            existing = self.client.find_one("dashboard", {"uuid": dashboard["uuid"]})
+            if existing:
+                return existing
+        if dashboard.get("slug"):
+            existing = self.client.find_one("dashboard", {"slug": dashboard["slug"]})
+            if existing:
+                return existing
+        return self.client.find_one(
+            "dashboard",
+            {"dashboard_title": title_from_dashboard_spec(dashboard)},
+        )
+
+    def _find_by_uuid_or_name(
+        self,
+        resource: Literal["database", "dataset", "chart"],
+        spec: dict[str, Any],
+        name_field: str,
+    ) -> dict[str, Any] | None:
+        if spec.get("uuid"):
+            existing = self.client.find_one(resource, {"uuid": spec["uuid"]})
+            if existing:
+                return existing
+        return self.client.find_one(resource, {name_field: spec[name_field]})
+
+    def _record(self, message: str) -> None:
+        self.result.actions.append(message)
+
+    @staticmethod
+    def _extract_id(response: dict[str, Any]) -> int:
+        result = response.get("result", response)
+        if isinstance(result, dict):
+            value = result.get("id")
+            if value is None:
+                value = result.get("table_id")
+        else:
+            value = None
+        if value is None:
+            raise RuntimeError(f"Superset response did not include an id: {response}")
+        return int(value)

--- a/superset-dashboards/superset_dashboards/json_utils.py
+++ b/superset-dashboards/superset_dashboards/json_utils.py
@@ -16,7 +16,19 @@
 # under the License.
 from __future__ import annotations
 
-import sys
-from pathlib import Path
+import json as _json  # noqa: TID251
+from typing import Any
 
-sys.path.insert(0, str(Path(__file__).parents[3] / "superset-dashboards"))
+JSONDecodeError = _json.JSONDecodeError
+
+
+def dumps(value: Any, *, sort_keys: bool = False, separators: tuple[str, str] | None = None) -> str:
+    """Serialize a value to JSON without importing the Superset app stack."""
+
+    return _json.dumps(value, sort_keys=sort_keys, separators=separators)
+
+
+def loads(value: str) -> Any:
+    """Deserialize a JSON string without importing the Superset app stack."""
+
+    return _json.loads(value)

--- a/superset-dashboards/superset_dashboards/layout.py
+++ b/superset-dashboards/superset_dashboards/layout.py
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from superset_dashboards.spec import stable_suffix
+
+
+@dataclass(frozen=True)
+class ChartLayout:
+    """Chart placement inputs for generated dashboard position_json."""
+
+    chart_id: int
+    slice_name: str
+    uuid: str | None = None
+    width: int = 12
+    height: int = 50
+
+
+def build_dashboard_position(charts: list[ChartLayout]) -> dict[str, Any]:
+    """Build a deterministic one-chart-per-row dashboard layout."""
+
+    position: dict[str, Any] = {
+        "DASHBOARD_VERSION_KEY": "v2",
+        "ROOT_ID": {"type": "ROOT", "id": "ROOT_ID", "children": ["GRID_ID"]},
+        "GRID_ID": {"type": "GRID", "id": "GRID_ID", "parents": ["ROOT_ID"], "children": []},
+    }
+
+    row_ids: list[str] = []
+    for index, chart in enumerate(charts, start=1):
+        suffix = stable_suffix(chart.slice_name)
+        row_id = f"ROW-{index}-{suffix}"
+        chart_node_id = f"CHART-{index}-{suffix}"
+        row_ids.append(row_id)
+
+        position[row_id] = {
+            "type": "ROW",
+            "id": row_id,
+            "parents": ["ROOT_ID", "GRID_ID"],
+            "children": [chart_node_id],
+            "meta": {"background": "BACKGROUND_TRANSPARENT"},
+        }
+        chart_meta: dict[str, Any] = {
+            "chartId": chart.chart_id,
+            "height": chart.height,
+            "sliceName": chart.slice_name,
+            "width": chart.width,
+        }
+        if chart.uuid:
+            chart_meta["uuid"] = chart.uuid
+        position[chart_node_id] = {
+            "type": "CHART",
+            "id": chart_node_id,
+            "parents": ["ROOT_ID", "GRID_ID", row_id],
+            "children": [],
+            "meta": chart_meta,
+        }
+
+    position["GRID_ID"]["children"] = row_ids
+    return position

--- a/superset-dashboards/superset_dashboards/layout.py
+++ b/superset-dashboards/superset_dashboards/layout.py
@@ -39,7 +39,12 @@ def build_dashboard_position(charts: list[ChartLayout]) -> dict[str, Any]:
     position: dict[str, Any] = {
         "DASHBOARD_VERSION_KEY": "v2",
         "ROOT_ID": {"type": "ROOT", "id": "ROOT_ID", "children": ["GRID_ID"]},
-        "GRID_ID": {"type": "GRID", "id": "GRID_ID", "parents": ["ROOT_ID"], "children": []},
+        "GRID_ID": {
+            "type": "GRID",
+            "id": "GRID_ID",
+            "parents": ["ROOT_ID"],
+            "children": [],
+        },
     }
 
     row_ids: list[str] = []

--- a/superset-dashboards/superset_dashboards/spec.py
+++ b/superset-dashboards/superset_dashboards/spec.py
@@ -16,13 +16,14 @@
 # under the License.
 from __future__ import annotations
 
-import json
 import re
 from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+from superset_dashboards import json_utils as json
 
 
 class SpecError(ValueError):
@@ -101,8 +102,7 @@ def substitute_chart_placeholders(value: Any, chart_ids_by_name: dict[str, int])
     """Replace chart ID placeholders in imported layout templates."""
 
     replacements = {
-        f"__CHART_ID:{name}__": chart_id
-        for name, chart_id in chart_ids_by_name.items()
+        f"__CHART_ID:{name}__": chart_id for name, chart_id in chart_ids_by_name.items()
     }
     if chart_ids_by_name:
         replacements["__CHART_ID__"] = next(iter(chart_ids_by_name.values()))
@@ -121,7 +121,7 @@ def title_from_dashboard_spec(dashboard: dict[str, Any]) -> str:
 def stable_suffix(value: str) -> str:
     """Create a stable, position_json-safe suffix from a user-facing label."""
 
-    suffix = re.sub(r"[^A-Za-z0-9_-]+", "-", value.strip()).strip("-")
+    suffix = re.sub(r"[^A-Za-z0-9]+", "-", value.strip()).strip("-")
     return suffix or "item"
 
 

--- a/superset-dashboards/superset_dashboards/spec.py
+++ b/superset-dashboards/superset_dashboards/spec.py
@@ -1,0 +1,164 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import json
+import re
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+class SpecError(ValueError):
+    """Raised when a dashboard automation spec is invalid."""
+
+
+def load_spec(
+    path: Path,
+    *,
+    database_sqlalchemy_uri: str | None = None,
+) -> dict[str, Any]:
+    """Load and validate a dashboard automation YAML spec."""
+
+    with path.open(encoding="utf-8") as file_obj:
+        loaded = yaml.safe_load(file_obj)
+    if not isinstance(loaded, dict):
+        raise SpecError(f"{path} must contain a YAML object")
+
+    spec = deepcopy(loaded)
+    database = _required_mapping(spec, "database")
+    dataset = _required_mapping(spec, "dataset")
+    dashboard = _required_mapping(spec, "dashboard")
+    charts = spec.get("charts")
+
+    if database_sqlalchemy_uri:
+        database["sqlalchemy_uri"] = database_sqlalchemy_uri
+
+    _require_string(database, "database_name")
+    _require_string(database, "sqlalchemy_uri")
+    _require_string(dataset, "table_name")
+    _require_string(dashboard, "title", aliases=("dashboard_title",))
+
+    if not isinstance(charts, list) or not charts:
+        raise SpecError("charts must be a non-empty list")
+    for index, chart in enumerate(charts, start=1):
+        if not isinstance(chart, dict):
+            raise SpecError(f"charts[{index}] must be a YAML object")
+        _require_string(chart, "slice_name")
+        _require_string(chart, "viz_type")
+
+    return spec
+
+
+def ensure_json_string(value: Any) -> str:
+    """Return a deterministic JSON string for REST fields that expect strings."""
+
+    if value is None:
+        return "{}"
+    if isinstance(value, str):
+        json.loads(value)
+        return value
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def pick_fields(source: dict[str, Any], allowed_fields: set[str]) -> dict[str, Any]:
+    """Copy allowed fields from a spec mapping, dropping keys set to None."""
+
+    return {
+        field: value
+        for field, value in source.items()
+        if field in allowed_fields and value is not None
+    }
+
+
+def substitute_dataset_placeholders(value: Any, dataset_id: int) -> Any:
+    """Replace dataset placeholders in chart params with REST API datasource IDs."""
+
+    replacements: dict[str, Any] = {
+        "__DATASET_ID__": f"{dataset_id}__table",
+        "__DATASET_ID_INT__": dataset_id,
+    }
+    return _substitute_placeholders(value, replacements)
+
+
+def substitute_chart_placeholders(value: Any, chart_ids_by_name: dict[str, int]) -> Any:
+    """Replace chart ID placeholders in imported layout templates."""
+
+    replacements = {
+        f"__CHART_ID:{name}__": chart_id
+        for name, chart_id in chart_ids_by_name.items()
+    }
+    if chart_ids_by_name:
+        replacements["__CHART_ID__"] = next(iter(chart_ids_by_name.values()))
+    return _substitute_placeholders(value, replacements)
+
+
+def title_from_dashboard_spec(dashboard: dict[str, Any]) -> str:
+    """Return the dashboard title using either supported spec spelling."""
+
+    title = dashboard.get("title", dashboard.get("dashboard_title"))
+    if not isinstance(title, str) or not title.strip():
+        raise SpecError("dashboard.title must be a non-empty string")
+    return title
+
+
+def stable_suffix(value: str) -> str:
+    """Create a stable, position_json-safe suffix from a user-facing label."""
+
+    suffix = re.sub(r"[^A-Za-z0-9_-]+", "-", value.strip()).strip("-")
+    return suffix or "item"
+
+
+def _substitute_placeholders(value: Any, replacements: dict[str, Any]) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _substitute_placeholders(item, replacements)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_substitute_placeholders(item, replacements) for item in value]
+    if isinstance(value, str):
+        if value in replacements:
+            return replacements[value]
+        substituted = value
+        for placeholder, replacement in replacements.items():
+            substituted = substituted.replace(placeholder, str(replacement))
+        return substituted
+    return value
+
+
+def _required_mapping(spec: dict[str, Any], key: str) -> dict[str, Any]:
+    value = spec.get(key)
+    if not isinstance(value, dict):
+        raise SpecError(f"{key} must be a YAML object")
+    return value
+
+
+def _require_string(
+    mapping: dict[str, Any],
+    key: str,
+    *,
+    aliases: tuple[str, ...] = (),
+) -> None:
+    value = mapping.get(key)
+    for alias in aliases:
+        value = value or mapping.get(alias)
+    if not isinstance(value, str) or not value.strip():
+        names = ", ".join((key, *aliases))
+        raise SpecError(f"Missing required string field: {names}")

--- a/tests/unit_tests/superset_dashboards/conftest.py
+++ b/tests/unit_tests/superset_dashboards/conftest.py
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parents[3] / "superset-dashboards"))

--- a/tests/unit_tests/superset_dashboards/test_deployer.py
+++ b/tests/unit_tests/superset_dashboards/test_deployer.py
@@ -1,0 +1,184 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+import pytest
+
+from superset_dashboards.deployer import DashboardDeployer
+
+
+class FakeClient:
+    def __init__(
+        self,
+        existing: dict[tuple[str, str, Any], dict[str, Any]] | None = None,
+    ) -> None:
+        self.existing = existing or {}
+        self.posts: list[tuple[str, dict[str, Any]]] = []
+        self.puts: list[tuple[str, dict[str, Any]]] = []
+        self.gets: list[str] = []
+        self.exports: list[tuple[int, Path]] = []
+        self.imports: list[Path] = []
+        self.fail_put_endpoint: str | None = None
+
+    def find_one(
+        self,
+        resource: Literal["database", "dataset", "chart", "dashboard"],
+        filters: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        [(field, value)] = list(filters.items())
+        return self.existing.get((resource, field, value))
+
+    def post_json(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
+        self.posts.append((endpoint, payload))
+        if endpoint == "/api/v1/database/":
+            return {"result": {"id": 10}}
+        if endpoint == "/api/v1/dataset/get_or_create/":
+            return {"result": {"table_id": 20}}
+        if endpoint == "/api/v1/dashboard/":
+            return {"result": {"id": 30}}
+        if endpoint == "/api/v1/chart/":
+            return {"result": {"id": 40, "uuid": "chart-uuid"}}
+        return {"result": {"id": 999}}
+
+    def put_json(self, endpoint: str, payload: dict[str, Any]) -> dict[str, Any]:
+        if endpoint == self.fail_put_endpoint:
+            raise RuntimeError("write failed")
+        self.puts.append((endpoint, payload))
+        return {"result": {"id": int(endpoint.rstrip("/").rsplit("/", 1)[-1])}}
+
+    def get_json(
+        self,
+        endpoint: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        self.gets.append(endpoint)
+        return {"result": {"id": 1}}
+
+    def export_dashboard(self, dashboard_id: int, output_path: Path) -> Path:
+        self.exports.append((dashboard_id, output_path))
+        return output_path
+
+    def import_dashboard_zip(self, zip_path: Path, *, overwrite: bool = True) -> None:
+        self.imports.append(zip_path)
+
+
+def minimal_spec() -> dict[str, Any]:
+    return {
+        "database": {
+            "database_name": "analytics",
+            "sqlalchemy_uri": "postgresql://service-account",
+            "expose_in_sqllab": True,
+        },
+        "dataset": {"schema": "public", "table_name": "loan_applications"},
+        "dashboard": {
+            "title": "Staging - Automation Smoke Test",
+            "slug": "staging-automation-smoke-test",
+            "published": False,
+        },
+        "charts": [
+            {
+                "slice_name": "Smoke - Latest Rows",
+                "viz_type": "table",
+                "params": {"datasource": "__DATASET_ID__", "row_limit": 50},
+            }
+        ],
+    }
+
+
+def test_dry_run_records_actions_without_writes() -> None:
+    client = FakeClient()
+    deployer = DashboardDeployer(client, dry_run=True)
+
+    result = deployer.deploy(minimal_spec())
+
+    assert result.dashboard_id == 0
+    assert client.posts == []
+    assert client.puts == []
+    assert "Creating database analytics" in result.actions
+    assert "Creating chart Smoke - Latest Rows" in result.actions
+
+
+def test_deploy_builds_current_superset_rest_payloads() -> None:
+    client = FakeClient()
+    deployer = DashboardDeployer(client, snapshot_dir=Path("snapshots"))
+
+    result = deployer.deploy(minimal_spec())
+
+    assert result.database_id == 10
+    assert result.dataset_id == 20
+    assert result.dashboard_id == 30
+    assert result.chart_ids == {"Smoke - Latest Rows": 40}
+    chart_payload = dict(client.posts)["/api/v1/chart/"]
+    assert chart_payload["datasource_id"] == 20
+    assert chart_payload["datasource_type"] == "table"
+    assert chart_payload["dashboards"] == [30]
+    assert json.loads(chart_payload["params"]) == {
+        "datasource": "20__table",
+        "row_limit": 50,
+    }
+
+    dashboard_layout_payload = client.puts[-1][1]
+    position = json.loads(dashboard_layout_payload["position_json"])
+    assert position["CHART-1-Smoke-Latest-Rows"]["meta"]["chartId"] == 40
+    assert dashboard_layout_payload["is_managed_externally"] is True
+
+
+def test_existing_dashboard_is_snapshot_and_rolled_back_on_failure() -> None:
+    existing_dashboard = {
+        ("dashboard", "slug", "staging-automation-smoke-test"): {
+            "id": 30,
+            "slug": "staging-automation-smoke-test",
+            "dashboard_title": "Staging - Automation Smoke Test",
+        },
+        ("database", "database_name", "analytics"): {
+            "id": 10,
+            "database_name": "analytics",
+        },
+    }
+    client = FakeClient(existing_dashboard)
+    client.fail_put_endpoint = "/api/v1/database/10"
+    deployer = DashboardDeployer(client, snapshot_dir=Path("snapshots"))
+
+    with pytest.raises(RuntimeError, match="write failed"):
+        deployer.deploy(minimal_spec())
+
+    assert client.exports[0][0] == 30
+    assert client.imports == [client.exports[0][1]]
+
+
+def test_skip_upsert_runs_smoke_tests_against_existing_assets() -> None:
+    existing = {
+        ("dashboard", "slug", "staging-automation-smoke-test"): {"id": 30},
+        ("database", "database_name", "analytics"): {"id": 10},
+        ("dataset", "table_name", "loan_applications"): {"id": 20},
+        ("chart", "slice_name", "Smoke - Latest Rows"): {"id": 40},
+    }
+    client = FakeClient(existing)
+    deployer = DashboardDeployer(client, skip_upsert=True, run_smoke_tests=True)
+
+    result = deployer.deploy(minimal_spec())
+
+    assert result.dashboard_id == 30
+    assert result.chart_ids == {"Smoke - Latest Rows": 40}
+    assert client.posts == []
+    assert client.puts == []
+    assert client.gets == ["/api/v1/dashboard/30", "/api/v1/chart/40/data/"]

--- a/tests/unit_tests/superset_dashboards/test_deployer.py
+++ b/tests/unit_tests/superset_dashboards/test_deployer.py
@@ -16,12 +16,11 @@
 # under the License.
 from __future__ import annotations
 
-import json
 from pathlib import Path
 from typing import Any, Literal
 
 import pytest
-
+from superset_dashboards import json_utils as json
 from superset_dashboards.deployer import DashboardDeployer
 
 

--- a/tests/unit_tests/superset_dashboards/test_spec.py
+++ b/tests/unit_tests/superset_dashboards/test_spec.py
@@ -1,0 +1,110 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from superset_dashboards.layout import ChartLayout, build_dashboard_position
+from superset_dashboards.spec import (
+    SpecError,
+    ensure_json_string,
+    load_spec,
+    substitute_dataset_placeholders,
+)
+
+
+def test_load_spec_overrides_database_uri(tmp_path: Path) -> None:
+    spec_path = tmp_path / "dashboard.yaml"
+    spec_path.write_text(
+        yaml.safe_dump(
+            {
+                "database": {
+                    "database_name": "analytics",
+                    "sqlalchemy_uri": "postgresql://placeholder",
+                },
+                "dataset": {"schema": "public", "table_name": "loans"},
+                "dashboard": {"title": "Loan Ops", "slug": "loan-ops"},
+                "charts": [{"slice_name": "Rows", "viz_type": "table"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    spec = load_spec(
+        spec_path,
+        database_sqlalchemy_uri="postgresql://service-account",
+    )
+
+    assert spec["database"]["sqlalchemy_uri"] == "postgresql://service-account"
+
+
+def test_load_spec_requires_charts(tmp_path: Path) -> None:
+    spec_path = tmp_path / "dashboard.yaml"
+    spec_path.write_text(
+        yaml.safe_dump(
+            {
+                "database": {
+                    "database_name": "analytics",
+                    "sqlalchemy_uri": "postgresql://placeholder",
+                },
+                "dataset": {"table_name": "loans"},
+                "dashboard": {"title": "Loan Ops"},
+                "charts": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SpecError, match="charts"):
+        load_spec(spec_path)
+
+
+def test_ensure_json_string_is_deterministic() -> None:
+    assert ensure_json_string({"b": 2, "a": 1}) == '{"a":1,"b":2}'
+    assert json.loads(ensure_json_string('{"already":"json"}')) == {"already": "json"}
+
+
+def test_substitute_dataset_placeholders() -> None:
+    value = {
+        "datasource": "__DATASET_ID__",
+        "queries": [{"datasource_id": "__DATASET_ID_INT__"}],
+    }
+
+    assert substitute_dataset_placeholders(value, 42) == {
+        "datasource": "42__table",
+        "queries": [{"datasource_id": 42}],
+    }
+
+
+def test_build_dashboard_position_is_deterministic() -> None:
+    position = build_dashboard_position(
+        [ChartLayout(chart_id=7, slice_name="Smoke - Latest Rows", uuid="abc")]
+    )
+
+    assert position["GRID_ID"]["children"] == ["ROW-1-Smoke-Latest-Rows"]
+    chart = position["CHART-1-Smoke-Latest-Rows"]
+    assert chart["meta"] == {
+        "chartId": 7,
+        "height": 50,
+        "sliceName": "Smoke - Latest Rows",
+        "uuid": "abc",
+        "width": 12,
+    }

--- a/tests/unit_tests/superset_dashboards/test_spec.py
+++ b/tests/unit_tests/superset_dashboards/test_spec.py
@@ -16,17 +16,16 @@
 # under the License.
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import pytest
 import yaml
-
-from superset_dashboards.layout import ChartLayout, build_dashboard_position
+from superset_dashboards import json_utils as json
+from superset_dashboards.layout import build_dashboard_position, ChartLayout
 from superset_dashboards.spec import (
-    SpecError,
     ensure_json_string,
     load_spec,
+    SpecError,
     substitute_dataset_placeholders,
 )
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### SUMMARY
Adds a standalone `superset-dashboards` REST API deployer for version-controlled dashboard automation. The utility reads YAML specs, authenticates with Superset's current `/login/` + CSRF flow, performs lookup-then-upsert for databases/datasets/charts/dashboards, exports pre-deploy dashboard snapshots, and can roll back from the snapshot if a write fails. It also includes a starter smoke-test dashboard spec and focused unit tests.

API and MCP doc: https://docs.google.com/document/d/18ttIGIKo5kB2mOo7mFMg2NXol1J55Q930r64gY9NGdI/edit?tab=t.0 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Not applicable; this is a CLI/tooling change.

### TESTING INSTRUCTIONS
- `python3 -m pytest --confcutdir="tests/unit_tests/superset_dashboards" "tests/unit_tests/superset_dashboards"`
- `GITHUB_BASE_REF=avenmaster python3 -m pre_commit run --files $(sort -u /tmp/dashboard_files.txt)` where `/tmp/dashboard_files.txt` contains the branch-changed files

### ADDITIONAL INFORMATION
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [x] Introduces new feature or API
- [ ] Removes existing feature or API
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-395e7243-4e1a-4b02-8592-d494b6d16e44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-395e7243-4e1a-4b02-8592-d494b6d16e44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

